### PR TITLE
feat: 프로필 화면 구현 및 모듈화된 위젯 구조 적용

### DIFF
--- a/lib/features/profile/presentation/profile_screen.dart
+++ b/lib/features/profile/presentation/profile_screen.dart
@@ -1,37 +1,45 @@
 import 'package:flutter/material.dart';
+import 'widgets/profile_info_card.dart';
+//import 'widgets/green_market_button.dart';
+import 'widgets/activity_section.dart';
+import 'widgets/settings_section.dart';
 
-class ProfilePage extends StatelessWidget {
-  const ProfilePage({super.key});
+class ProfileScreen extends StatelessWidget {
+  const ProfileScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: const Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.person,
-              size: 80,
-              color: Colors.purple,
-            ),
-            SizedBox(height: 20),
-            Text(
-              '마이페이지',
-              style: TextStyle(
-                fontSize: 24,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-            SizedBox(height: 10),
-            Text(
-              '내 정보를 관리해보세요!',
-              style: TextStyle(
-                fontSize: 16,
-                color: Colors.grey,
-              ),
-            ),
-          ],
+    return Scaffold(
+      backgroundColor: Colors.grey[100],
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const SizedBox(height: 8),
+              
+              // 프로필 정보 카드
+              const ProfileInfoCard(),
+              
+              const SizedBox(height: 16),
+              
+              // 그린 마켓 버튼
+              //const GreenMarketButton(),
+              
+              //const SizedBox(height: 24),
+              
+              // 나의 활동 섹션
+              const ActivitySection(),
+              
+              const SizedBox(height: 24),
+              
+              // 앱 설정 섹션
+              const SettingsSection(),
+              
+              const SizedBox(height: 20), // 하단 여백
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/profile/presentation/widgets/activity_section.dart
+++ b/lib/features/profile/presentation/widgets/activity_section.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+
+class ActivitySection extends StatelessWidget {
+  const ActivitySection({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // 섹션 제목
+        Text(
+          '나의 활동',
+          style: Theme.of(context).textTheme.titleLarge?.copyWith(
+            fontWeight: FontWeight.bold,
+            color: Colors.black87,
+          ),
+        ),
+        
+        const SizedBox(height: 12),
+        
+        // 찜한 꿀팁
+        Container(
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(12),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.grey.withOpacity(0.1),
+                spreadRadius: 1,
+                blurRadius: 4,
+                offset: const Offset(0, 2),
+              ),
+            ],
+          ),
+          child: Semantics(
+            label: '내가 찜한 꿀팁',
+            button: true,
+            child: ListTile(
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: 16,
+                vertical: 8,
+              ),
+              leading: Container(
+                width: 40,
+                height: 40,
+                decoration: BoxDecoration(
+                  color: Colors.orange[100],
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Icon(
+                  Icons.bookmark,
+                  color: Colors.orange[600],
+                  size: 20,
+                ),
+              ),
+              title: Text(
+                '내가 찜한 꿀팁',
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              trailing: Icon(
+                Icons.arrow_forward_ios,
+                color: Colors.grey[400],
+                size: 16,
+              ),
+              onTap: () {
+                // TODO: 찜한 꿀팁 페이지로 이동
+                print('찜한 꿀팁 클릭됨');
+              },
+            ),
+          ),
+        ),
+        
+        const SizedBox(height: 8),
+        
+        // 완료한 챌린지
+        Container(
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(12),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.grey.withOpacity(0.1),
+                spreadRadius: 1,
+                blurRadius: 4,
+                offset: const Offset(0, 2),
+              ),
+            ],
+          ),
+          child: Semantics(
+            label: '완료한 챌린지',
+            button: true,
+            child: ListTile(
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: 16,
+                vertical: 8,
+              ),
+              leading: Container(
+                width: 40,
+                height: 40,
+                decoration: BoxDecoration(
+                  color: Colors.purple[100],
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Icon(
+                  Icons.emoji_events,
+                  color: Colors.purple[600],
+                  size: 20,
+                ),
+              ),
+              title: Text(
+                '완료한 챌린지',
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              trailing: Icon(
+                Icons.arrow_forward_ios,
+                color: Colors.grey[400],
+                size: 16,
+              ),
+              onTap: () {
+                // TODO: 완료한 챌린지 페이지로 이동
+                print('완료한 챌린지 클릭됨');
+              },
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/profile/presentation/widgets/green_market_button.dart
+++ b/lib/features/profile/presentation/widgets/green_market_button.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+class GreenMarketButton extends StatelessWidget {
+  final bool isEnabled;
+  final VoidCallback? onPressed;
+  
+  const GreenMarketButton({
+    super.key,
+    this.isEnabled = true,
+    this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: Semantics(
+        label: '그린 마켓: 포인트로 지역화폐 교환하기',
+        button: true,
+        enabled: isEnabled,
+        child: ElevatedButton(
+          onPressed: isEnabled ? (onPressed ?? () {
+            // TODO: 그린 마켓 기능 구현
+            print('그린 마켓 버튼 클릭됨');
+          }) : null,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.teal[600],
+            foregroundColor: Colors.white,
+            disabledBackgroundColor: Colors.grey[400],
+            disabledForegroundColor: Colors.white,
+            elevation: 0,
+            padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '그린 마켓',
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      '포인트로 지역화폐 교환하기',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Colors.white.withOpacity(0.9),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Icon(
+                Icons.arrow_forward_ios,
+                color: Colors.white,
+                size: 16,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/profile/presentation/widgets/profile_info_card.dart
+++ b/lib/features/profile/presentation/widgets/profile_info_card.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'green_market_button.dart';
+
+class ProfileInfoCard extends StatelessWidget {
+  const ProfileInfoCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.grey.withOpacity(0.1),
+            spreadRadius: 1,
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 프로필 섹션
+          Row(
+            children: [
+              // 프로필 이미지 (CircleAvatar 사용)
+              Semantics(
+                label: '프로필 이미지',
+                child: CircleAvatar(
+                  radius: 30,
+                  backgroundColor: Colors.teal[100],
+                  child: Text(
+                    'Me',
+                    style: TextStyle(
+                      color: Colors.teal[800],
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ),
+              
+              const SizedBox(width: 16),
+              
+              // 사용자 정보
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '에코세이버',
+                      style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: Colors.black87,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            'ecosaver@email.com',
+                            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                              color: Colors.grey[600],
+                            ),
+                          ),
+                        ),
+                        // 프로필 수정 버튼
+                        Semantics(
+                          label: '프로필 수정 버튼',
+                          button: true,
+                          child: InkWell(
+                            onTap: () {
+                              // TODO: 프로필 수정 기능 구현
+                              print('프로필 수정 버튼 클릭됨');
+                            },
+                            borderRadius: BorderRadius.circular(16),
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 12,
+                                vertical: 6,
+                              ),
+                              decoration: BoxDecoration(
+                                color: Colors.grey[200],
+                                borderRadius: BorderRadius.circular(16),
+                              ),
+                              child: Text(
+                                '프로필 수정',
+                                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                  color: Colors.grey[700],
+                                  fontWeight: FontWeight.w500,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          
+          //const SizedBox(height: 20),
+          
+          // 포인트 섹션
+          Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              //color: Colors.teal[50],
+              borderRadius: BorderRadius.circular(12),
+              //border: Border.all(color: Colors.teal[200]!, width: 1),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '나의 그린 포인트',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Colors.teal[800],
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  '1,250 P',
+                  style: Theme.of(context).textTheme.headlineLarge?.copyWith(
+                    color: Colors.teal[600],
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                
+              ],
+            ),
+          ),
+          const GreenMarketButton()
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/profile/presentation/widgets/settings_section.dart
+++ b/lib/features/profile/presentation/widgets/settings_section.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+
+class SettingsSection extends StatelessWidget {
+  const SettingsSection({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // 섹션 제목
+        Text(
+          '앱 설정',
+          style: Theme.of(context).textTheme.titleLarge?.copyWith(
+            fontWeight: FontWeight.bold,
+            color: Colors.black87,
+          ),
+        ),
+        
+        const SizedBox(height: 12),
+        
+        // 알림 설정
+        Container(
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(12),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.grey.withOpacity(0.1),
+                spreadRadius: 1,
+                blurRadius: 4,
+                offset: const Offset(0, 2),
+              ),
+            ],
+          ),
+          child: Semantics(
+            label: '알림 설정',
+            button: true,
+            child: ListTile(
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: 16,
+                vertical: 8,
+              ),
+              leading: Container(
+                width: 40,
+                height: 40,
+                decoration: BoxDecoration(
+                  color: Colors.blue[100],
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Icon(
+                  Icons.notifications,
+                  color: Colors.blue[600],
+                  size: 20,
+                ),
+              ),
+              title: Text(
+                '알림 설정',
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              trailing: Icon(
+                Icons.arrow_forward_ios,
+                color: Colors.grey[400],
+                size: 16,
+              ),
+              onTap: () {
+                // TODO: 알림 설정 페이지로 이동
+                print('알림 설정 클릭됨');
+              },
+            ),
+          ),
+        ),
+        
+        const SizedBox(height: 8),
+        
+        // 로그아웃
+        Container(
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(12),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.grey.withOpacity(0.1),
+                spreadRadius: 1,
+                blurRadius: 4,
+                offset: const Offset(0, 2),
+              ),
+            ],
+          ),
+          child: Semantics(
+            label: '로그아웃',
+            button: true,
+            child: ListTile(
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: 16,
+                vertical: 8,
+              ),
+              leading: Container(
+                width: 40,
+                height: 40,
+                decoration: BoxDecoration(
+                  color: Colors.red[100],
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Icon(
+                  Icons.logout,
+                  color: Colors.red[600],
+                  size: 20,
+                ),
+              ),
+              title: Text(
+                '로그아웃',
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  fontWeight: FontWeight.w500,
+                  color: Colors.red[600],
+                ),
+              ),
+              onTap: () {
+                // TODO: 로그아웃 확인 다이얼로그
+                _showLogoutDialog(context);
+              },
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _showLogoutDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('로그아웃'),
+          content: const Text('정말 로그아웃하시겠습니까?'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('취소'),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+                // TODO: 실제 로그아웃 로직 구현
+                print('로그아웃 실행됨');
+              },
+              child: Text(
+                '로그아웃',
+                style: TextStyle(color: Colors.red[600]),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,7 +45,7 @@ class _MainNavigationPageState extends State<MainNavigationPage> {
     const HomePage(),
     const ChallengePage(),
     const TipsPage(),
-    const ProfilePage(),
+    const ProfileScreen(),
   ];
 
   void _onItemTapped(int index) {


### PR DESCRIPTION
# 🚀 PR 전설의 시작

## 🧑‍💻 작성자
- 닉네임: `@나`

---

## 🎯 이번 PR의 퀘스트
- [x] 버그를 처치했다 🐛🔪
- [x] 기능을 소환했다 🪄✨
- [x] UI를 미모로 치장했다 💅
- [x] 코드 정리를 시도했다 🧹
- [x] 문서를 새겼다 📜

---

## 📦 변경 사항 요약
마이페이지를 완전히 새로 만들었슈
프로필화면: 사용자 정보 + 포인트 + 그린마켓 
위젯분리해서 작성햇슈


---

## 🔮 테스트 방법
1. `flutter run` 주문을 외운다.
2. 앱 실행 후 하단 네비게이션에서 "마이페이지" 탭 클릭 👆
3. 프로필 카드에 "Me" 원형 아바타와 "에코세이버" 이름이 보이면 성공 ✅
4. "프로필 수정" 버튼 터치하면 콘솔에 "클릭됨" 메시지 출력 📱
5. "그린 마켓" 버튼도 터치하면 콘솔에 메시지 출력 🛒
6. "나의 활동" 섹션의 "찜한 꿀팁", "완료한 챌린지" 터치 테스트 🏆
7. "앱 설정" 섹션의 "알림 설정", "로그아웃" 터치 테스트 (로그아웃은 다이얼로그 뜸!) 🔔
8. 앱이 폭발하지 않으면 성공 ☄️
9. 이상한 프레임 드랍이 안 보이면 완벽 ⭐️

---

## 🧙‍♂️ 리뷰어에게 전하는 주문
- 이 PR은 마이페이지의 완전한 리뉴얼이다! 🎊
- 코드 보다가 "오 이렇게 깔끔하게 만들었구나!" 하면 바로 Approve 😆
- 위젯을 파일별로 분리한 게 정말 좋은 구조라고 칭찬해줘 👏
- 접근성도 신경 써서 Semantics 위젯까지 사용했다고 자랑해줘 🎯
- 리뷰 코멘트는 마법서에 기록된다 ✏️📖

---

## ⚠️ 주의사항
- 이 PR 머지 안 하면, 마이페이지가 영원히 텅 빈 상태로 남는다… 👻
- 하지만 머지하면 아름다운 프로필 화면이 완성된다! ✨

\