### PR TITLE
fix:tap effects 추가

### DIFF
--- a/lib/features/profile/presentation/widgets/activity_section.dart
+++ b/lib/features/profile/presentation/widgets/activity_section.dart
@@ -20,23 +20,31 @@ class ActivitySection extends StatelessWidget {
         const SizedBox(height: 12),
         
         // 찜한 꿀팁
-        Container(
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(12),
-            boxShadow: [
-              BoxShadow(
-                color: Colors.grey.withOpacity(0.1),
-                spreadRadius: 1,
-                blurRadius: 4,
-                offset: const Offset(0, 2),
-              ),
-            ],
-          ),
+        Material(
+          color: Colors.transparent,
           child: Semantics(
             label: '내가 찜한 꿀팁',
             button: true,
-            child: ListTile(
+            child: Ink(
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(12),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.grey.withOpacity(0.1),
+                    spreadRadius: 1,
+                    blurRadius: 4,
+                    offset: const Offset(0, 2),
+                  ),
+                ],
+              ),
+              child: InkWell(
+                borderRadius: BorderRadius.circular(12),
+                onTap: () {
+                  // TODO: 찜한 꿀팁 페이지로 이동
+                  print('찜한 꿀팁 클릭됨');
+                },
+                child: ListTile(
               contentPadding: const EdgeInsets.symmetric(
                 horizontal: 16,
                 vertical: 8,
@@ -60,15 +68,13 @@ class ActivitySection extends StatelessWidget {
                   fontWeight: FontWeight.w500,
                 ),
               ),
-              trailing: Icon(
+                  trailing: Icon(
                 Icons.arrow_forward_ios,
                 color: Colors.grey[400],
                 size: 16,
               ),
-              onTap: () {
-                // TODO: 찜한 꿀팁 페이지로 이동
-                print('찜한 꿀팁 클릭됨');
-              },
+                ),
+              ),
             ),
           ),
         ),
@@ -76,23 +82,31 @@ class ActivitySection extends StatelessWidget {
         const SizedBox(height: 8),
         
         // 완료한 챌린지
-        Container(
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(12),
-            boxShadow: [
-              BoxShadow(
-                color: Colors.grey.withOpacity(0.1),
-                spreadRadius: 1,
-                blurRadius: 4,
-                offset: const Offset(0, 2),
-              ),
-            ],
-          ),
+        Material(
+          color: Colors.transparent,
           child: Semantics(
             label: '완료한 챌린지',
             button: true,
-            child: ListTile(
+            child: Ink(
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(12),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.grey.withOpacity(0.1),
+                    spreadRadius: 1,
+                    blurRadius: 4,
+                    offset: const Offset(0, 2),
+                  ),
+                ],
+              ),
+              child: InkWell(
+                borderRadius: BorderRadius.circular(12),
+                onTap: () {
+                  // TODO: 완료한 챌린지 페이지로 이동
+                  print('완료한 챌린지 클릭됨');
+                },
+                child: ListTile(
               contentPadding: const EdgeInsets.symmetric(
                 horizontal: 16,
                 vertical: 8,
@@ -116,15 +130,13 @@ class ActivitySection extends StatelessWidget {
                   fontWeight: FontWeight.w500,
                 ),
               ),
-              trailing: Icon(
+                  trailing: Icon(
                 Icons.arrow_forward_ios,
                 color: Colors.grey[400],
                 size: 16,
               ),
-              onTap: () {
-                // TODO: 완료한 챌린지 페이지로 이동
-                print('완료한 챌린지 클릭됨');
-              },
+                ),
+              ),
             ),
           ),
         ),

--- a/lib/features/profile/presentation/widgets/profile_info_card.dart
+++ b/lib/features/profile/presentation/widgets/profile_info_card.dart
@@ -73,26 +73,31 @@ class ProfileInfoCard extends StatelessWidget {
                         Semantics(
                           label: '프로필 수정 버튼',
                           button: true,
-                          child: InkWell(
-                            onTap: () {
-                              // TODO: 프로필 수정 기능 구현
-                              print('프로필 수정 버튼 클릭됨');
-                            },
-                            borderRadius: BorderRadius.circular(16),
-                            child: Container(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 12,
-                                vertical: 6,
-                              ),
-                              decoration: BoxDecoration(
-                                color: Colors.grey[200],
-                                borderRadius: BorderRadius.circular(16),
-                              ),
-                              child: Text(
-                                '프로필 수정',
-                                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                  color: Colors.grey[700],
-                                  fontWeight: FontWeight.w500,
+                          child: Material(
+                            color: Colors.transparent,
+                            child: InkWell(
+                              onTap: () {
+                                // TODO: 프로필 수정 기능 구현
+                                print('프로필 수정 버튼 클릭됨');
+                              },
+                              borderRadius: BorderRadius.circular(16),
+                              child: Ink(
+                                decoration: BoxDecoration(
+                                  color: Colors.grey[200],
+                                  borderRadius: BorderRadius.circular(16),
+                                ),
+                                child: Padding(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 12,
+                                    vertical: 6,
+                                  ),
+                                  child: Text(
+                                    '프로필 수정',
+                                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                      color: Colors.grey[700],
+                                      fontWeight: FontWeight.w500,
+                                    ),
+                                  ),
                                 ),
                               ),
                             ),

--- a/lib/features/profile/presentation/widgets/settings_section.dart
+++ b/lib/features/profile/presentation/widgets/settings_section.dart
@@ -20,23 +20,31 @@ class SettingsSection extends StatelessWidget {
         const SizedBox(height: 12),
         
         // 알림 설정
-        Container(
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(12),
-            boxShadow: [
-              BoxShadow(
-                color: Colors.grey.withOpacity(0.1),
-                spreadRadius: 1,
-                blurRadius: 4,
-                offset: const Offset(0, 2),
-              ),
-            ],
-          ),
+        Material(
+          color: Colors.transparent,
           child: Semantics(
             label: '알림 설정',
             button: true,
-            child: ListTile(
+            child: Ink(
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(12),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.grey.withOpacity(0.1),
+                    spreadRadius: 1,
+                    blurRadius: 4,
+                    offset: const Offset(0, 2),
+                  ),
+                ],
+              ),
+              child: InkWell(
+                borderRadius: BorderRadius.circular(12),
+                onTap: () {
+                  // TODO: 알림 설정 페이지로 이동
+                  print('알림 설정 클릭됨');
+                },
+                child: ListTile(
               contentPadding: const EdgeInsets.symmetric(
                 horizontal: 16,
                 vertical: 8,
@@ -60,15 +68,13 @@ class SettingsSection extends StatelessWidget {
                   fontWeight: FontWeight.w500,
                 ),
               ),
-              trailing: Icon(
+                  trailing: Icon(
                 Icons.arrow_forward_ios,
                 color: Colors.grey[400],
                 size: 16,
               ),
-              onTap: () {
-                // TODO: 알림 설정 페이지로 이동
-                print('알림 설정 클릭됨');
-              },
+                ),
+              ),
             ),
           ),
         ),
@@ -76,23 +82,31 @@ class SettingsSection extends StatelessWidget {
         const SizedBox(height: 8),
         
         // 로그아웃
-        Container(
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(12),
-            boxShadow: [
-              BoxShadow(
-                color: Colors.grey.withOpacity(0.1),
-                spreadRadius: 1,
-                blurRadius: 4,
-                offset: const Offset(0, 2),
-              ),
-            ],
-          ),
+        Material(
+          color: Colors.transparent,
           child: Semantics(
             label: '로그아웃',
             button: true,
-            child: ListTile(
+            child: Ink(
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(12),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.grey.withOpacity(0.1),
+                    spreadRadius: 1,
+                    blurRadius: 4,
+                    offset: const Offset(0, 2),
+                  ),
+                ],
+              ),
+              child: InkWell(
+                borderRadius: BorderRadius.circular(12),
+                onTap: () {
+                  // TODO: 로그아웃 확인 다이얼로그
+                  _showLogoutDialog(context);
+                },
+                child: ListTile(
               contentPadding: const EdgeInsets.symmetric(
                 horizontal: 16,
                 vertical: 8,
@@ -110,17 +124,15 @@ class SettingsSection extends StatelessWidget {
                   size: 20,
                 ),
               ),
-              title: Text(
+                  title: Text(
                 '로그아웃',
                 style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                   fontWeight: FontWeight.w500,
                   color: Colors.red[600],
                 ),
               ),
-              onTap: () {
-                // TODO: 로그아웃 확인 다이얼로그
-                _showLogoutDialog(context);
-              },
+                ),
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
## 🚀 PR 전설의 시작

## 🧑‍💻 작성자
- 닉네임: `@나`

---

## 🎯 이번 PR의 퀘스트
- [ ] 버그를 처치했다 🐛🔪
- [ ] 기능을 소환했다 🪄✨
- [x] UI를 미모로 치장했다 💅
- [x] 코드 정리를 시도했다 🧹
- [ ] 문서를 새겼다 📜

---

## 📦 변경 사항 요약
- 프로필 화면의 탭 피드백 일관화 했ㅇ므
  - `프로필 수정`, `내가 찜한 꿀팁`, `완료한 챌린지`, `알림 설정`, `로그아웃`에 리플 이펙트 적용
  - 패턴 적용: Material(transparent) → Ink(decoration) → InkWell(onTap) → ListTile로 모두 통일
  - 둥근 모서리 클리핑 + 그림자 유지하며 리플 자연스럽게 표시


변경 파일
- `lib/features/profile/presentation/widgets/profile_info_card.dart`
- `lib/features/profile/presentation/widgets/activity_section.dart`
- `lib/features/profile/presentation/widgets/settings_section.dart`

---

## 🔮 테스트 방법
1. `flutter run` 실행
2. 마이페이지 이동
3. 아래 항목 터치 시 리플이 둥근 모서리에 맞춰 정상 표시되는지 확인
   - 프로필 수정 / 내가 찜한 꿀팁 / 완료한 챌린지 / 알림 설정 / 로그아웃
4. 그림자와 배경 스타일이 기존과 동일한지 확인
5. 콘솔에 각 항목의 클릭 로그가 출력되는지 확인

---

## 🧙‍♂️ 리뷰어에게 전하는 주문
- 탭 피드백이 모든 항목에서 동일하게 작동하는지

---

## ⚠️ 주의사항
즐거운 한가위 보내시길