### PR TITLE
feat:자취꿀팁 화면 UI 구현

### DIFF
--- a/lib/features/tips/presentation/tips_screen.dart
+++ b/lib/features/tips/presentation/tips_screen.dart
@@ -1,39 +1,316 @@
 import 'package:flutter/material.dart';
 
-class TipsPage extends StatelessWidget {
+class TipsPage extends StatefulWidget {
   const TipsPage({super.key});
 
   @override
+  State<TipsPage> createState() => _TipsPageState();
+}
+
+class _TipsPageState extends State<TipsPage> {
+  final TextEditingController _searchController = TextEditingController();
+
+  final List<_TipItem> _allTips = <_TipItem>[
+    _TipItem(
+      leadingEmoji: '🤔',
+      title: '음식물 쓰레기, 일반 봉투에 버려도 되나요?',
+      tags: <String>['분리수거'],
+    ),
+    _TipItem(
+      leadingIcon: Icons.bolt,
+      leadingIconColor: Colors.orange,
+      title: '에어컨, 껐다 켰다 vs 계속 켜기, 뭐가 더 절약될까요?',
+      tags: <String>['전기요금', '생활꿀팁'],
+    ),
+  ];
+
+  String _query = '';
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.lightbulb,
-              size: 80,
-              color: Colors.orange,
-            ),
-            SizedBox(height: 20),
-            Text(
-              '자취꿀팁 페이지',
-              style: TextStyle(
-                fontSize: 24,
-                fontWeight: FontWeight.bold,
+    final List<_TipItem> visibleTips = _allTips
+        .where((t) => t.title.toLowerCase().contains(_query.toLowerCase()))
+        .toList();
+
+    return Scaffold(
+      backgroundColor: const Color(0xFFF6F7F9),
+      body: SafeArea(
+        child: CustomScrollView(
+          slivers: <Widget>[
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
+                child: _TipsHeader(),
               ),
             ),
-            SizedBox(height: 10),
-            Text(
-              '유용한 자취 팁을 확인해보세요!',
-              style: TextStyle(
-                fontSize: 16,
-                color: Colors.grey,
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                child: _SearchField(
+                  controller: _searchController,
+                  hintText: '궁금한 집을 검색해보세요',
+                  onChanged: (String value) => setState(() => _query = value),
+                ),
               ),
             ),
+            const SliverToBoxAdapter(child: SizedBox(height: 16)),
+            SliverList.separated(
+              itemBuilder: (BuildContext context, int index) {
+                final _TipItem tip = visibleTips[index];
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  child: _TipCard(
+                    tip: tip,
+                    onTap: () {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text('선택: ${tip.title}'),
+                          behavior: SnackBarBehavior.floating,
+                        ),
+                      );
+                    },
+                  ),
+                );
+              },
+              separatorBuilder: (_, __) => const SizedBox(height: 12),
+              itemCount: visibleTips.length,
+            ),
+            const SliverToBoxAdapter(child: SizedBox(height: 24)),
           ],
         ),
       ),
     );
   }
+}
+
+class _TipsHeader extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          '슬기로운 자취 생활',
+          style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                fontWeight: FontWeight.w800,
+                color: Colors.black87,
+              ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          '사회초년생을 위한 필수 꿀팁 모음',
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: Colors.grey[600],
+              ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SearchField extends StatelessWidget {
+  final TextEditingController controller;
+  final String hintText;
+  final ValueChanged<String>? onChanged;
+
+  const _SearchField({
+    required this.controller,
+    required this.hintText,
+    this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: '검색창',
+      textField: true,
+      child: Material(
+        color: Colors.transparent,
+        child: Ink(
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(12),
+            boxShadow: <BoxShadow>[
+              BoxShadow(
+                color: Colors.grey.withOpacity(0.12),
+                blurRadius: 8,
+                offset: const Offset(0, 2),
+              ),
+            ],
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 2),
+            child: Row(
+              children: <Widget>[
+                Icon(Icons.search, color: Colors.grey[500]),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: TextField(
+                    controller: controller,
+                    onChanged: onChanged,
+                    decoration: InputDecoration(
+                      hintText: hintText,
+                      hintStyle: TextStyle(color: Colors.grey[500]),
+                      border: InputBorder.none,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TipCard extends StatelessWidget {
+  final _TipItem tip;
+  final VoidCallback? onTap;
+
+  const _TipCard({required this.tip, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: tip.title,
+      button: true,
+      child: Material(
+        color: Colors.transparent,
+        child: Ink(
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(14),
+            boxShadow: <BoxShadow>[
+              BoxShadow(
+                color: Colors.black.withOpacity(0.06),
+                blurRadius: 10,
+                spreadRadius: 1,
+                offset: const Offset(0, 2),
+              ),
+            ],
+          ),
+          child: InkWell(
+            borderRadius: BorderRadius.circular(14),
+            onTap: onTap,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      _TipLeading(tip: tip),
+                      const SizedBox(width: 10),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: <Widget>[
+                            Wrap(
+                              spacing: 8,
+                              runSpacing: 6,
+                              children: tip.tags
+                                  .map((String tag) => _TagChip(text: tag))
+                                  .toList(),
+                            ),
+                            const SizedBox(height: 8),
+                            Text(
+                              tip.title,
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .titleMedium
+                                  ?.copyWith(
+                                    fontWeight: FontWeight.w700,
+                                    color: Colors.black87,
+                                  ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TipLeading extends StatelessWidget {
+  final _TipItem tip;
+  const _TipLeading({required this.tip});
+
+  @override
+  Widget build(BuildContext context) {
+    final Widget container = Container(
+      width: 40,
+      height: 40,
+      decoration: BoxDecoration(
+        color: Colors.grey[100],
+        borderRadius: BorderRadius.circular(10),
+      ),
+      alignment: Alignment.center,
+      child: tip.leadingEmoji != null
+          ? Text(
+              tip.leadingEmoji!,
+              style: const TextStyle(fontSize: 22),
+            )
+          : Icon(
+              tip.leadingIcon ?? Icons.lightbulb,
+              color: tip.leadingIconColor ?? Colors.teal,
+              size: 22,
+            ),
+    );
+    return container;
+  }
+}
+
+class _TagChip extends StatelessWidget {
+  final String text;
+  const _TagChip({required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: const Color(0xFFE8F5E9), // light green-ish
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Text(
+        '#$text',
+        style: TextStyle(
+          color: Colors.green[700],
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+class _TipItem {
+  final String title;
+  final List<String> tags;
+  final String? leadingEmoji;
+  final IconData? leadingIcon;
+  final Color? leadingIconColor;
+
+  const _TipItem({
+    required this.title,
+    required this.tags,
+    this.leadingEmoji,
+    this.leadingIcon,
+    this.leadingIconColor,
+  });
 }


### PR DESCRIPTION
## 🚀 PR 전설의 시작

## 🧑‍💻 작성자
- 닉네임: `@나`

---

## 🎯 이번 PR의 퀘스트
- [ ] 버그를 처치했다 🐛🔪
- [x] 기능을 소환했다 🪄✨
- [x] UI를 미모로 치장했다 💅
- [x] 코드 정리를 시도했다 🧹
- [ ] 문서를 새겼다 📜

---

## 📦 변경 사항 요약
- 자취꿀팁(Tips) 레이아웃 구현
  - 헤더(타이틀/서브텍스트), 검색창, 카드 리스트 레이아웃 추가
  - 카드에 태그 칩, 아이콘/이모지 리딩, 리플/그림자 적용
  - 실시간 검색(제목 기준 필터) 및 탭 스낵바 피드백
- 프로필 화면 일부 위젯에 머티리얼 리플 패턴 정리
  - Material → Ink(decoration) → InkWell 구조로 통일, 둥근 모서리 클리핑 일치 

---

## 🔮 테스트 방법
1. `flutter run` 실행
2. 하단 탭에서 자취꿀팁 이동
3. 검색창에 키워드 입력 → 리스트가 즉시 필터되는지 확인
4. 각 카드 탭 → 리플/스낵바 노출 확인, 그림자/모서리 클리핑 정상 여부 확인
5. 프로필 화면의 각 항목(프로필 수정/찜/완료/알림/로그아웃) 탭 시 리플 표시 확인

---

## 🧙‍♂️ 리뷰어에게 전하는 주문
- 리플이 둥근 모서리 안에서 자연스럽게 퍼지는지 봐주세요
- 검색 UX(속도/매칭 기준)나 카드 간 간격/타이포 피드백 환영합니다
- 필요 시 상세 페이지 네비게이션/태그 필터 바 확장 검토 가능

---

## ⚠️ 주의사항
- Material 위젯에는 decoration이 없어 Ink(decoration)로 처리했습니다
- borderRadius는 Ink와 InkWell에 동일하게 지정해야 리플이 깔끔히 클리핑됩니다