### PR TITLE
security:  환경변수 완전 분리 (.env + local.properties)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Kakao SDK
+# 카카오 개발자 콘솔에서 발급받은 네이티브 앱 키를 입력하세요
+KAKAO_NATIVE_APP_KEY=your_kakao_native_app_key_here
+
+# Backend API
+# 백엔드 서버 주소를 입력하세요
+API_BASE_URL=http://your-api-server-url

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 .svn/
 migrate_working_dir/
 
+# Environment variables
+.env
+
 # IntelliJ related
 *.iml
 *.ipr

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -52,6 +52,10 @@ android {
             ndk {
                 abiFilters "armeabi-v7a", "arm64-v8a", "x86_64"
             }
+            
+            // Kakao Native App Key를 manifestPlaceholders로 주입
+            def kakaoAppKey = localProperties.getProperty('KAKAO_NATIVE_APP_KEY')
+            manifestPlaceholders += [KAKAO_NATIVE_APP_KEY: kakaoAppKey ?: ""]
         }  
 
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -37,7 +37,7 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="kakaob70b066e6c735236882c7e05c089e3f6" android:host="oauth" />
+                <data android:scheme="kakao${KAKAO_NATIVE_APP_KEY}" android:host="oauth" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/lib/config/api_config.dart
+++ b/lib/config/api_config.dart
@@ -1,5 +1,8 @@
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
 class ApiConfig {
-  static const String baseUrl = 'http://billow.210-178-1-132.nip.io';
+  // 환경변수에서 API Base URL 가져오기
+  static String get baseUrl => dotenv.env['API_BASE_URL'] ?? 'http://billow.210-178-1-132.nip.io';
 
   // Auth
   static const String kakaoLogin = '/auth/kakao';

--- a/lib/features/home/data/bill_remote_datasource.dart
+++ b/lib/features/home/data/bill_remote_datasource.dart
@@ -2,11 +2,13 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:http_parser/http_parser.dart';
 import 'package:image_picker/image_picker.dart';
+import '../../../config/api_config.dart';
 import '../data/bill_response_model.dart';
 
 // 실제 API 통신을 담당하는 클래스입니다.
 class BillRemoteDataSource {
-  static const String _baseUrl = 'http://billow.210-178-1-132.nip.io/swagger-ui/index.html';
+  // ApiConfig에서 baseUrl을 가져옵니다
+  static String get _baseUrl => ApiConfig.baseUrl;
 
   Future<BillResponseModel> uploadBill({
     required String billType,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:billow/features/landing/presentation/splash_screen.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'features/home/presentation/home_screen.dart';
 import 'features/challenge/presentation/challenge_screen.dart';
 import 'features/tips/presentation/tips_screen.dart';
@@ -7,8 +8,17 @@ import 'features/profile/presentation/profile_screen.dart';
 import 'features/auth/presentation/auth_test_screen.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 
-void main() {
-  KakaoSdk.init(nativeAppKey: 'b70b066e6c735236882c7e05c089e3f6');
+Future<void> main() async {
+  // .env 파일 로드
+  await dotenv.load(fileName: '.env');
+  
+  // 환경변수에서 카카오 네이티브 앱 키 가져오기
+  final kakaoNativeAppKey = dotenv.env['KAKAO_NATIVE_APP_KEY'];
+  if (kakaoNativeAppKey == null || kakaoNativeAppKey.isEmpty) {
+    throw Exception('KAKAO_NATIVE_APP_KEY is not set in .env file');
+  }
+  
+  KakaoSdk.init(nativeAppKey: kakaoNativeAppKey);
   runApp(const MyApp());
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -174,6 +174,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_dotenv:
+    dependency: "direct main"
+    description:
+      name: flutter_dotenv
+      sha256: b7c7be5cd9f6ef7a78429cabd2774d3c4af50e79cb2b7593e3d5d763ef95c61b
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.1"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   dio: ^5.4.0
   flutter_secure_storage: ^9.0.0
   kakao_flutter_sdk_user: ^1.9.5
+  flutter_dotenv: ^5.1.0
 
 dev_dependencies:
   flutter_test:
@@ -66,6 +67,7 @@ flutter:
   uses-material-design: true
   assets:
     - assets/images/
+    - .env
 
   # To add assets to your application, add an assets section, like this:
   # assets:


### PR DESCRIPTION
# 🚀 PR 전설의 시작

## 🧑‍💻 작성자
- 닉네임: `@나`

---

## 🎯 이번 PR의 퀘스트
- [ ] 버그를 처치했다 🐛🔪
- [x] 기능을 소환했다 🪄✨
- [ ] UI를 미모로 치장했다 💅
- [x] 코드 정리를 시도했다 🧹
- [ ] 문서를 새겼다 📜

---

## 📦 변경 사항 요약
> API 키가 Git에서 도망쳤다! 🏃‍♂️💨  
> 
> 하드코딩된 카카오 앱 키를 환경변수로 숨겼더니  
> GitHub에서 찾을 수 없게 되었다 🕵️‍♂️🔐  
> 
> **2개의 비밀 금고 생성:**  
> - `.env` (Flutter 소스코드용) 🗝️  
> - `local.properties` (Android Manifest용) 🔑  
> 
> 이제 API 키는 로컬에만 살고, Git에는 환영받지 못한다 ✋

진짜 말투 왜저래 

---

## 🔮 테스트 방법
1. **`.env.example`을 복사하여 `.env` 파일 생성**
   ```bash
   cp .env.example .env
   ```
2. **`.env` 파일에 실제 키 입력**
   ```env
   KAKAO_NATIVE_APP_KEY=실제_카카오_네이티브_앱_키
   API_BASE_URL=http://billow.210-178-1-132.nip.io
   ```
3. **`android/local.properties` 파일에도 키 추가 (없으면 추가)**
   ```properties
   KAKAO_NATIVE_APP_KEY=실제_카카오_네이티브_앱_키
   ```
4. `flutter pub get` 주문을 외운다 📦
5. `flutter run` 주문을 외운다 🚀
6. 카카오 로그인이 정상 작동하면 성공 ✨
7. Git에 `.env` 파일이 안 올라가는지 확인 (`git status`) 🔒

---

## 🧙‍♂️ 리뷰어에게 전하는 주문

- **특히 주목:** `.env`와 `local.properties`가 `.gitignore`에 잘 들어갔는지 확인해주세요! 🔍

---

## ⚠️ 주의사항
- 이 PR 머지 안 하면, 빌드의 저주가 영원히 내린다… 👻
- env랑 local.properties 물어보셈
- 보안상의 위험을 대비해서 수정
---
