### PR TITLE
fix(splash): 스플래시 자동 로그인 로직 개선

### DIFF
--- a/lib/config/api_config.dart
+++ b/lib/config/api_config.dart
@@ -2,7 +2,13 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 class ApiConfig {
   // 환경변수에서 API Base URL 가져오기
-  static String get baseUrl => dotenv.env['API_BASE_URL'] ?? 'http://billow.210-178-1-132.nip.io';
+  static String get baseUrl {
+    final value = dotenv.env['API_BASE_URL'];
+    if (value == null || value.isEmpty) {
+      throw StateError('Missing API_BASE_URL in .env');
+    }
+    return value;
+  }
 
   // Auth
   static const String kakaoLogin = '/auth/kakao';

--- a/lib/features/landing/presentation/splash_screen.dart
+++ b/lib/features/landing/presentation/splash_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../../core/animation/fade_route.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
+import 'package:kakao_flutter_sdk_common/kakao_flutter_sdk_common.dart';
 import '../../../services/auth_service.dart';
 import 'login_screen.dart';
 import '../../../main.dart';
@@ -22,29 +23,41 @@ class _SplashScreenState extends State<SplashScreen> {
   _navigateToLogin() async {
     await Future.delayed(const Duration(milliseconds: 1200));
     try {
-      // 조용한 로그인: 카카오 세션 존재 시 idToken 발급 후 서버 로그인 시도
-      OAuthToken token;
+      // 조용한 로그인: 기존 토큰으로 서버 로그인 시도
       try {
-        // 이미 세션이 있으면 바로 me() 호출로 확인
+        // 기존 토큰 확인 (카카오 창 뜨지 않음)
+        final accessTokenInfo = await UserApi.instance.accessTokenInfo();
+        if (accessTokenInfo == null) {
+          if (!mounted) return _goLogin();
+          return _goLogin();
+        }
+        
+        // 기존 토큰으로 사용자 정보 확인 (세션 검증)
         await UserApi.instance.me();
-        token = await UserApi.instance.loginWithKakaoAccount();
+
+        // Kakao SDK에 저장된 토큰 조회
+        final OAuthToken? stored = await TokenManagerProvider.instance.manager.getToken();
+        final accessToken = stored?.accessToken ?? '';
+        if (accessToken.isEmpty) {
+          if (!mounted) return _goLogin();
+          return _goLogin();
+        }
+        
+        // 서버 로그인 시도 (accessToken 사용)
+        final ok = await AuthService.loginWithKakaoAccessToken(accessToken);
+        if (!mounted) return;
+        if (ok) {
+          Navigator.pushReplacement(
+            context,
+            FadeRoute(page: const MainNavigationPage()),
+          );
+        } else {
+          _goLogin();
+        }
       } catch (_) {
-        // 세션 없으면 로그인 화면으로 이동
+        // 세션 없거나 실패하면 로그인 화면으로 이동
         if (!mounted) return _goLogin();
         return _goLogin();
-      }
-
-      final idToken = token.idToken;
-      if (idToken == null) return _goLogin();
-      final ok = await AuthService.loginWithKakaoIdToken(idToken);
-      if (!mounted) return;
-      if (ok) {
-        Navigator.pushReplacement(
-          context,
-          FadeRoute(page: const MainNavigationPage()), // 자동 로그인 성공 시 메인 화면으로 이동
-        );
-      } else {
-        _goLogin();
       }
     } catch (_) {
       _goLogin();

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 import '../config/api_config.dart';
 import 'api_client.dart';
@@ -10,18 +11,47 @@ class AuthService {
   // idToken은 카카오 SDK에서 발급받은 값
   static Future<bool> loginWithKakaoIdToken(String idToken) async {
     try {
+      // Debug: idToken 전달 여부 확인
+      debugPrint('[Auth] sending idToken to server: len=${idToken.length}');
+      debugPrint('[Auth] idToken for Swagger test:\n$idToken');
       final Response response = await ApiClient.dio.post(
         ApiConfig.kakaoLogin,
         data: jsonEncode({ 'idToken': idToken }),
       );
 
+      debugPrint('[Auth] /auth/kakao status: ${response.statusCode}');
       final data = response.data as Map<String, dynamic>;
       final String access = data['accessToken'] as String;
       final String refresh = data['refreshToken'] as String;
 
       await TokenStorage.saveTokens(access: access, refresh: refresh);
+      debugPrint('[Auth] tokens saved: accessLen=${access.length}, refreshLen=${refresh.length}');
       return true;
     } catch (e) {
+      debugPrint('[Auth][ERROR] loginWithKakaoIdToken failed: $e');
+      return false;
+    }
+  }
+
+  // 자동 로그인용: accessToken으로 서버 로그인
+  static Future<bool> loginWithKakaoAccessToken(String accessToken) async {
+    try {
+      debugPrint('[Auth] sending accessToken to server: len=${accessToken.length}');
+      final Response response = await ApiClient.dio.post(
+        ApiConfig.kakaoLogin,
+        data: jsonEncode({ 'accessToken': accessToken }),
+      );
+
+      debugPrint('[Auth] /auth/kakao status: ${response.statusCode}');
+      final data = response.data as Map<String, dynamic>;
+      final String access = data['accessToken'] as String;
+      final String refresh = data['refreshToken'] as String;
+
+      await TokenStorage.saveTokens(access: access, refresh: refresh);
+      debugPrint('[Auth] tokens saved: accessLen=${access.length}, refreshLen=${refresh.length}');
+      return true;
+    } catch (e) {
+      debugPrint('[Auth][ERROR] loginWithKakaoAccessToken failed: $e');
       return false;
     }
   }
@@ -47,16 +77,19 @@ class AuthService {
         // 카카오톡으로 로그인 시도
         try {
           final OAuthToken token = await UserApi.instance.loginWithKakaoTalk();
+          debugPrint('[Kakao] loginWithKakaoTalk success: hasIdToken=${token.idToken != null}, accessLen=${token.accessToken.length}');
           return token.idToken;
         } catch (e) {
           // 카카오톡 로그인 실패 시 계정 로그인으로 폴백
           print('카카오톡 로그인 실패, 계정 로그인으로 폴백: $e');
           final OAuthToken token = await UserApi.instance.loginWithKakaoAccount();
+          debugPrint('[Kakao] fallback loginWithKakaoAccount success: hasIdToken=${token.idToken != null}, accessLen=${token.accessToken.length}');
           return token.idToken;
         }
       } else {
         // 카카오톡 미설치 시 계정 로그인
         final OAuthToken token = await UserApi.instance.loginWithKakaoAccount();
+        debugPrint('[Kakao] loginWithKakaoAccount success (no talk): hasIdToken=${token.idToken != null}, accessLen=${token.accessToken.length}');
         return token.idToken;
       }
     } catch (e) {
@@ -76,6 +109,7 @@ class AuthService {
       // 주의: scopes 파라미터는 kakao_flutter_sdk_user 최신 버전에서만 지원됨
       // 현재 버전에서는 loginWithKakaoAccount()가 기본적으로 openid 포함
       final OAuthToken token = await UserApi.instance.loginWithKakaoAccount();
+      debugPrint('[Kakao] requestAdditionalScope -> hasIdToken=${token.idToken != null}, accessLen=${token.accessToken.length}');
       return token.idToken;
     } catch (e) {
       print('추가 동의 요청 실패: $e');


### PR DESCRIPTION
- 스플래시에서 불필요한 카카오 팝업 제거
- 기존: 스플래시 → 카카오 팝업 → 로그인 → 카카오 팝업 (중복)
- 개선: 스플래시 → 로그인 → 카카오 팝업 (1회)
- accessTokenInfo()로 세션 확인만 수행 (팝업 안 뜸)
- loginWithKakaoAccount() 제거하여 중복 인증 방지

# 🚀 PR 전설의 시작

## 🧑‍💻 작성자
- 닉네임: `@나`

---

## 🎯 이번 PR의 퀘스트
- [ ] 버그를 처치했다 🐛🔪
- [ ] 기능을 소환했다 🪄✨
- [ ] UI를 미모로 치장했다 💅
- [ ] 코드 정리를 시도했다 🧹
- [ ] 문서를 새겼다 📜

---

## 📦 변경 사항 요약
> 여기에 "내가 무슨 마법을 부렸는지" 간단히 써라  
예: 로그인 버튼이 이제 춤춘다 💃

---

## 🔮 테스트 방법
1. `flutter run` 주문을 외운다.
2. 앱이 폭발하지 않으면 성공 ☄️
3. 이상한 프레임 드랍이 안 보이면 완벽 ⭐️

---

## 🧙‍♂️ 리뷰어에게 전하는 주문
- 이 PR은 세상을 구할 수도, 망칠 수도 있다 🌍🔥
- 코드 보다가 웃음 터지면 바로 Approve 😆
- 리뷰 코멘트는 마법서에 기록된다 ✏️📖

---

## ⚠️ 주의사항
- 이 PR 머지 안 하면, 빌드의 저주가 영원히 내린다… 👻