### PR TITLE
fix: 닉네임 수정 시 무한 로딩 해결

### DIFF
--- a/lib/features/profile/presentation/widgets/profile_info_card.dart
+++ b/lib/features/profile/presentation/widgets/profile_info_card.dart
@@ -73,10 +73,13 @@ class _ProfileInfoCardState extends State<ProfileInfoCard> {
                 ),
               );
 
-              final success = await UserApiService.updateNickname(newNickname);
+              try {
+                final success = await UserApiService.updateNickname(newNickname);
 
-              if (mounted) {
-                Navigator.pop(context); // 로딩 다이얼로그 닫기
+                if (!mounted) return;
+                
+                // 로딩 다이얼로그 닫기
+                Navigator.of(context, rootNavigator: true).pop();
 
                 if (success) {
                   ScaffoldMessenger.of(context).showSnackBar(
@@ -88,6 +91,15 @@ class _ProfileInfoCardState extends State<ProfileInfoCard> {
                     const SnackBar(content: Text('닉네임 변경에 실패했습니다')),
                   );
                 }
+              } catch (e) {
+                if (!mounted) return;
+                
+                // 로딩 다이얼로그 닫기
+                Navigator.of(context, rootNavigator: true).pop();
+                
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text('에러 발생: $e')),
+                );
               }
             },
             child: const Text('저장'),


### PR DESCRIPTION
# 🚀 PR 전설의 시작

## 🧑‍💻 작성자
- 닉네임: `@나`

---

## 🎯 이번 PR의 퀘스트
- [ ] 버그를 처치했다 🐛🔪
- [ ] 기능을 소환했다 🪄✨
- [ ] UI를 미모로 치장했다 💅
- [ ] 코드 정리를 시도했다 🧹
- [ ] 문서를 새겼다 📜

---

## 📦 변경 사항 요약
- 닉네임 수정 다이얼로그 로딩 무한루프 수정 (rootNavigator 사용)
- profileImageUrl nullable 처리 (서버에서 null 반환 시)
- UserInfo 모델 profileImageUrl을 String?으로 변경
- try-catch로 닉네임 수정 에러 핸들링 강화

---

## 🔮 테스트 방법
1. `flutter run` 주문을 외운다.
2. 앱이 폭발하지 않으면 성공 ☄️
3. 이상한 프레임 드랍이 안 보이면 완벽 ⭐️

---

## 🧙‍♂️ 리뷰어에게 전하는 주문
- 이 PR은 세상을 구할 수도, 망칠 수도 있다 🌍🔥
- 코드 보다가 웃음 터지면 바로 Approve 😆
- 리뷰 코멘트는 마법서에 기록된다 ✏️📖

---

## ⚠️ 주의사항
- 이 PR 머지 안 하면, 빌드의 저주가 영원히 내린다… 👻